### PR TITLE
Fix Docker build failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7 AS base
 ENV PYTHONUNBUFFERED 1
 RUN mkdir /code
 WORKDIR /code
-COPY requirements.txt /code/
+COPY *requirements.txt /code/
 RUN pip install -r requirements.txt
 COPY . /code/
 


### PR DESCRIPTION
requirements.txt depends on base_requirements.txt

STEP 6: RUN pip install -r requirements.txt
ERROR: Could not open requirements file: [Errno 2] No such file or directory: 'base_requirements.txt'