### PR TITLE
Adding state specific FAQ support and initial data for California

### DIFF
--- a/data/ca/contact.json
+++ b/data/ca/contact.json
@@ -1,0 +1,27 @@
+{
+    "agency":{
+        "name":"California Department of Education",
+        "cep_website":"https://www.cde.ca.gov/ls/nu/sn/cep.asp",
+        "cep_phone":[],
+        "cep_email":[]
+    },
+    "organizations":[
+        {
+            "name":"Nourish CA",
+            "website":"https://nourishca.org/",
+            "phone":[],
+            "email":[],
+            "cep_email":[],
+            "cep_phone":[]
+        },
+        {
+            "name":"San Diego Hunger Coalition",
+            "website":"https://www.sandiegohungercoalition.org/",
+            "phone":[],
+            "email":[],
+            "cep_email":[],
+            "cep_phone":[]
+        }    
+    ],
+    "additional":null
+}

--- a/data/ca/faq.html
+++ b/data/ca/faq.html
@@ -1,0 +1,4 @@
+<h3>Who can I contact at California Department of Education for help?</h3>
+<p>
+    School Nutrition Program County Specialists with the California Department of Education are available to <a href="https://www.cde.ca.gov/ls/nu/sn/cep.asp">provide assistance with CEP</a>. 
+</p>

--- a/server.py
+++ b/server.py
@@ -166,6 +166,7 @@ def district(state,code):
 #    district.evaluate_strategies()
     return jsonify(district.as_dict())
 
+# TODO set aggressive cache header
 @app.route('/api/states/', methods=['GET'])
 def states():
     states = {} # keyed by lowercase abbr (e.g. "ca"), with "name", "district_data", "about"
@@ -176,9 +177,15 @@ def states():
         if os.path.exists(os.path.join(DATA_FOLDER,state)):
             state_info = us.states.lookup(state)
             if state_info:
-                s = { "name":state_info.name, "fips":state_info.fips }
+                s = { "name":state_info.name, "fips":state_info.fips, "state_code": state }
                 if os.path.exists(os.path.join(DATA_FOLDER,state,"about.html")):
                     s["about"] = open(os.path.join(DATA_FOLDER,state,"about.html")).read()[:1024]
+                if os.path.exists(os.path.join(DATA_FOLDER,state,"faq.html")):
+                    s["faq"] = open(os.path.join(DATA_FOLDER,state,"faq.html")).read()[:1024]
+                if os.path.exists(os.path.join(DATA_FOLDER,state,"contact.json")):
+                    try:
+                        s["contact"] = json.loads(open(os.path.join(DATA_FOLDER,state,"contact.json")).read())
+                    except ValueError: pass
                 # District data is loaded through /api/districts/state/
                 if os.path.exists(os.path.join(STATIC_FOLDER,state,"districts.json")):
                     s["district_list"] = os.path.join("/static/",state,"districts.json")

--- a/src/components/ContactDisplay.vue
+++ b/src/components/ContactDisplay.vue
@@ -1,0 +1,51 @@
+<template>
+    <div class="contact">
+
+        <div v-if="contact.agency">
+            <h4>State</h4>
+            <p>
+                <a target="_blank" :href="contact.agency.cep_website">
+                    {{ contact.agency.name }}
+                </a>
+            </p>
+            <p v-for="phone in contact.agency.cep_phone" v-bind:key="phone">
+                <a :href="'tel:'+phone">{{ phone }}</a>
+            </p>
+            <p v-for="email in contact.agency.cep_email" v-bind:key="email">
+                <a :href="'mailto:'+email">{{ email }}</a>
+            </p>
+    </div>
+
+        <div v-if="contact.organizations.length > 0">
+            <h4 >Organizations</h4>
+            <ul>
+                <li v-for="org in contact.organizations" v-bind:key="org.name">
+                    <a target="_blank" :href="org.website">
+                        {{ org.name }}
+                    </a><br>
+                    <p v-for="phone in org.phone" v-bind:key="phone">
+                        <a :href="'tel:'+phone">{{ phone }}</a>
+                    </p>
+                    <p v-for="email in org.email" v-bind:key="email">
+                        <a :href="'mailto:'+email">{{ email }}</a>
+                    </p>
+                    <p v-for="phone in org.cep_phone" v-bind:key="phone">
+                        CEP Specific: <a :href="'tel:'+phone">{{ phone }}</a>
+                    </p>
+                    <p v-for="email in org.cep_email" v-bind:key="email">
+                        CEP Specific: <a :href="'mailto:'+email">{{ email }}</a>
+                    </p>
+                </li>
+            </ul>
+        </div>
+
+        <div v-if="contact.additional" v-html="contact.additional"></div>
+
+    </div>
+</template>
+
+<script>
+export default {
+    props: ["contact"],
+}
+</script>

--- a/src/components/Faq.vue
+++ b/src/components/Faq.vue
@@ -1,124 +1,189 @@
 <template>
- <section class="container mt-5">
-   <h1 class="headline text-center">Meals Count FAQ</h1>
-   <br>
+  <section class="container mt-5">
+    <h1 class="headline text-center">Meals Count FAQ</h1>
+    <br />
 
-  <h3>Is Meals Count free to use? </h3>
-  <p>
-      Yes, Meals Count is a free tool. You do not need an account, username, or password to access Meals Count. 
-  </p>
+    <h3>Is Meals Count free to use?</h3>
+    <p>
+      Yes, Meals Count is a free tool. You do not need an account, username, or
+      password to access Meals Count.
+    </p>
 
-  <h3>Is Meals Count available only for California schools?</h3>
-  <p>
-    Currently, Meals Count only pre-populates data for schools within California because that’s the data available to us. However, you can input your own school data into Meals Count. 
-  </p>
-  <p>
-    If you have access to school data and would like to partner with Meals Count to help us pre-populate data for your state, please <a href="https://www.mealscount.com/#/contact">contact us</a>.  
-  </p>
+    <h3>Is Meals Count available only for California schools?</h3>
+    <p>
+      Meals Count is available <strong>for all states</strong>! School district
+      data is pre-populated based upon the
+      <a
+        href="https://frac.org/research/resource-library/community-eligibility-cep-database"
+        >FRAC CEP database</a
+      >.
+    </p>
 
-  <h3>Why is the data displayed for my school district different than our actual data (e.g. enrollment, total eligible, average daily participation)?</h3>
-  <p>
-    The prepopulated California Meals Count data includes 
-  </p>
-  <ul>
-    <li>Enrollment data from the 2019-2020 school year;
-    <li>Estimated ISPs derived from direct certification for free school meals through CalFresh/SNAP and CalWORKs participation during July-November 2019; and 
-    <li>Average daily meal participation from April 2019.</li>
-  </ul>
-  <p>
-    Please note that the school list may include some charter schools and may exclude some preschools/early learning programs under your jurisdiction.
-  </p>
-  <p>
-    To get the best recommended grouping, we strongly encourage you to edit the school list and the data affiliated with each school to most accurately reflect current enrollment, eligibility, and meal participation.
-  </p>
+    <h3>
+      Why is the data displayed for my school district different than our actual
+      data (e.g. enrollment, total eligible, average daily participation)?
+    </h3>
+    <p>The prepopulated California Meals Count data includes</p>
+    <ul>
+      <li>Enrollment data from the 2019-2020 school year;</li>
+      <li>
+        Estimated ISPs derived from direct certification for free school meals
+        through CalFresh/SNAP and CalWORKs participation during July-November
+        2019; and
+      </li>
+      <li>Average daily meal participation from April 2019.</li>
+    </ul>
+    <p>
+      Please note that the school list may include some charter schools and may
+      exclude some preschools/early learning programs under your jurisdiction.
+    </p>
+    <p>
+      To get the best recommended grouping, we strongly encourage you to edit
+      the school list and the data affiliated with each school to most
+      accurately reflect current enrollment, eligibility, and meal
+      participation.
+    </p>
 
-  <h3>What is the source of the data included for each school/district?</h3>
-  <ul>
-    <li>Total Enrollment: <a href="https://www.cde.ca.gov/ds/sd/sd/filescupc.asp">2019-20 CALPADS UPC file</a>
-    <li>Total Eligible: direct certification through CalFresh/SNAP and CalWORKs only (<a href="https://www.cde.ca.gov/ds/sd/sd/filescupc.asp">2019-20 CALPADS UPC file</a>) 
-    <li>Average Daily Participation: CFPA analysis of April 2019 meal claim data from the California Department of Education</li> 
-  </ul>
-  <p>
-    Please use the edit function to input the most current data for your schools.
-  </p>
+    <h3>What is the source of the data included for each school/district?</h3>
+    <p>
+      The data is pre-loaded from
+      <a
+        href="https://frac.org/research/resource-library/community-eligibility-cep-database"
+        >FRAC CEP database</a
+      >. You will need to update this data with your projected Average Daily
+      Participation for Breakfast and Lunch, as well as updated anticipated
+      total enrollment and identified students.
+    </p>
 
-  <h3>Are charter schools included in Meals Counts? </h3>
-  <p>
-    Yes, charter schools that operate the National School Lunch Program and/or School Breakfast Program are included in Meals Count. 
-  </p>
+    <h3>Are charter schools included in Meals Counts?</h3>
+    <p>
+      Yes, charter schools that operate the National School Lunch Program and/or
+      School Breakfast Program are included in Meals Count.
+    </p>
 
-  <h3>What are the reimbursement rates used in Meals Count? </h3>
-  <p>
-    The reimbursement rates are preset to 2019-20 federal reimbursement rates for the National School Lunch Program and the School Breakfast Program. 
-  </p>
-  <p>
-    You can use the edit function to adjust the dollar amounts listed under “Federal Reimbursement Rates” as desired.
-  </p>
-  <p>
-    Please note that the rates don’t impact the grouping optimization feature, but we understand you need a calculation of estimated annual reimbursement in order to make informed decisions about your school meal programs. 
-  </p>
+    <h3>What are the reimbursement rates used in Meals Count?</h3>
+    <p>
+      The reimbursement rates are preset to 2019-20 federal reimbursement rates
+      for the National School Lunch Program and the School Breakfast Program.
+    </p>
+    <p>
+      You can use the edit function to adjust the dollar amounts listed under
+      “Federal Reimbursement Rates” as desired.
+    </p>
+    <p>
+      Please note that the rates don’t impact the grouping optimization feature,
+      but we understand you need a calculation of estimated annual reimbursement
+      in order to make informed decisions about your school meal programs.
+    </p>
 
-  <h3>Is state meal reimbursement (for California) included in the Estimated Annual Reimbursement? </h3>
-  <p>
-    No, the Estimated Annual Reimbursement <strong>only</strong> includes federal reimbursement. The estimate does <strong>not</strong> include any meal reimbursement funded by the state of California. Please consider including the projected state-funded reimbursement when assessing the feasibility of adopting CEP among your schools. 
-  </p>
-  <p>
-    Note: you can use the edit function to adjust the dollar amounts listed under “Federal Reimbursement Rates” as needed.
-  </p>
+    <h3>
+      Are state meal reimbursements included in the Estimated Annual
+      Reimbursement?
+    </h3>
+    <p>
+      No, the Estimated Annual Reimbursement <strong>only</strong> includes
+      federal reimbursement. The estimate does <strong>not</strong> include any
+      meal reimbursement funded by the states. Please consider including the
+      projected state-funded reimbursement when assessing the feasibility of
+      adopting CEP among your schools.
+    </p>
+    <p>
+      Note: you can use the edit function to adjust the dollar amounts listed
+      under “Federal Reimbursement Rates” as needed.
+    </p>
 
-  <h3>Are severe-need reimbursements included in the Estimated Annual Reimbursement? </h3>
-  <p>
-    No, the Estimated Annual Reimbursement does <strong>not</strong> automatically include the severe-need reimbursement. You can use the edit function to adjust the dollar amounts listed under “Federal Reimbursement Rates” as appropriate for your district. 
-  </p>
+    <h3>
+      Are severe-need reimbursements included in the Estimated Annual
+      Reimbursement?
+    </h3>
+    <p>
+      No, the Estimated Annual Reimbursement does
+      <strong>not</strong> automatically include the severe-need reimbursement.
+      You can use the edit function to adjust the dollar amounts listed under
+      “Federal Reimbursement Rates” as appropriate for your district.
+    </p>
 
-  <h3>Once I have results from Meals Count, what’s next?</h3>
-  <p>
-    Meals Count is a tool that groups schools in an effort to optimize reimbursement through CEP. Our aim is to help schools make informed decisions about adopting CEP to nourish the learning, growth, and development of their students. 
-  </p>
-  <p>
-    We recognize that many factors may impact your decision to implement CEP, including, but certainly not limited to participation rates, meal debt, revenue from a la carte sales, projected enrollment, and the prevalence of hunger and hardship amongst your students.
-  </p>
-  <p>
-    We recommend that you use the grouping results from Meals Count to help assess the financial, operational, and programmatic outcomes of implementing CEP. The <a href="https://www.fns.usda.gov/school-meals/community-eligibility-provision">United States Department of Agriculture</a> and the <a href="https://frac.org/community-eligibility">Food Research and Action Center</a> have developed financial calculators and other resources to help with those assessments. School Nutrition Program County Specialists with the California Department of Education are also available to <a href="https://www.cde.ca.gov/ls/nu/sn/cep.asp">provide assistance with CEP</a>. 
-  </p>
+    <h3>Once I have results from Meals Count, what’s next?</h3>
+    <p>
+      Meals Count is a tool that groups schools in an effort to optimize
+      reimbursement through CEP. Our aim is to help schools make informed
+      decisions about adopting CEP to nourish the learning, growth, and
+      development of their students.
+    </p>
+    <p>
+      We recognize that many factors may impact your decision to implement CEP,
+      including, but certainly not limited to participation rates, meal debt,
+      revenue from a la carte sales, projected enrollment, and the prevalence of
+      hunger and hardship amongst your students.
+    </p>
+    <p>
+      We recommend that you use the grouping results from Meals Count to help
+      assess the financial, operational, and programmatic outcomes of
+      implementing CEP. The
+      <a
+        href="https://www.fns.usda.gov/school-meals/community-eligibility-provision"
+        >United States Department of Agriculture</a
+      >
+      and the
+      <a href="https://frac.org/community-eligibility"
+        >Food Research and Action Center</a
+      >
+      have developed financial calculators and other resources to help with
+      those assessments. School Nutrition Program County Specialists with the
+      California Department of Education are also available to
+      <a href="https://www.cde.ca.gov/ls/nu/sn/cep.asp"
+        >provide assistance with CEP</a
+      >.
+    </p>
 
-  <h3>How do the Meals Count algorithms (aka “strategies”) work?</h3>
-  <p>
-    For more about the algorithms behind Meals Count, please see: <a href="https://www.mealscount.com/#/algorithms">https://www.mealscount.com/#/algorithms</a>
-  </p>
-  
-  <h3>Have questions about the ins and outs of the Community Eligibility Provision?</h3>
-  <p>
-    <em>An FAQ about CEP is coming soon!</em>
-  </p>
+    <h3>How do the Meals Count algorithms (aka “strategies”) work?</h3>
+    <p>
+      For more about the algorithms behind Meals Count, please see:
+      <a href="https://www.mealscount.com/#/algorithms"
+        >https://www.mealscount.com/#/algorithms</a
+      >
+    </p>
 
- </section>
+    <h3>
+      Have questions about the ins and outs of the Community Eligibility
+      Provision?
+    </h3>
+    <p>
+      <em>An FAQ about CEP is coming soon!</em>
+    </p>
+
+    <h2 class="headline text-center">State Specific FAQs &amp; Contact Information</h2>
+    <div>
+      <div class="row">
+        <div v-for="state in faq_states" v-bind:key="state.abbr" class="col-sm-3">
+          <router-link
+            :to="{name:'faq-state', params: {state_code:state.state_code} }"
+            >
+            {{ state.name }}
+          </router-link>
+        </div>
+      </div>
+    </div>
+  </section>
 </template>
 
 
+<script>
+export default {
+  computed: {
+    states() {
+      return this.$store.getters.get_states;
+    },
+    faq_states() {
+      return Object.values(this.$store.getters.get_states).filter( s => s.faq != undefined);
+    },
+  },
+};
+</script>
 
 <style scoped>
-
-
-
-.panel {
-  padding: 0 18px;
-  background-color: white;
- 
-}
-
-#app {
-  font-family: "Avenir", Helvetica, Arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  text-align: start;
-  color: #2c3e50;
-  margin-top: 60px;
-}
-
 h3 {
   margin-top: 40px;
 }
-
 </style>
 

--- a/src/components/StateDetail.vue
+++ b/src/components/StateDetail.vue
@@ -8,10 +8,21 @@
           <strong>ALSO NOTE that to see accurate estimates you MUST
             import the latest data for your district!</strong>
         </div>
+
         <div class="row">
             <h1 class="col-sm-6">{{ state.name }}</h1>
             <div class="district-filter col-sm-2 offset-sm-4 "><input type="text" placeholder="Filter Districts" v-model="district_filter" /></div>
             <div class="col-sm-12" v-html="state.about"></div>
+
+           <div class="col-sm-12 mb-3 mt-3 " v-if="state.faq != null || state.contact != null">
+               <router-link
+                 class="btn btn-primary"
+                 :to="{name:'faq-state', params: {state_code:state.state_code} }"
+                 >
+                 FAQs and Contact Information for {{ state.name }}
+               </router-link>
+           </div>
+
         </div>
         <div class="row">
             <table  @mouseover="hover = true" @mouseleave="hover = false" class="table col-sm district-table">

--- a/src/components/StateFaq.vue
+++ b/src/components/StateFaq.vue
@@ -1,0 +1,54 @@
+<template>
+ <section class="container mt-5">
+    <router-link :to="{name:'faq'}">&laquo; Back to FAQ</router-link>
+
+    <h1 class="headline text-center mb-4">Meals Count FAQ - {{ state.name }}</h1>
+
+
+    <div class="faq" v-html="state.faq"></div>
+
+    <div class="card" v-if="state.contact">
+        <div class="card-header">
+            <h2 id="contact">Contact Information for {{ state.name }}</h2>
+        </div>
+        <div class="card-body">
+            <ContactDisplay v-if="state.contact"  v-bind:contact="state.contact" />
+        </div>
+    </div>
+
+    <div class="district-link center m-4 text-center">
+        <router-link class="btn btn-primary" :to="{name:'state-detail', params: {state_code:state_code} }" >
+            View Districts in {{ state.name }}
+        </router-link>
+    </div>
+
+ </section>
+</template>
+
+
+<script>
+import ContactDisplay from "./ContactDisplay.vue";
+
+export default {
+    components:{ContactDisplay},
+    props: ["state_code"],
+    computed: {
+        state() {
+            return this.$store.getters.get_state(this.state_code);
+        }
+    },
+}
+</script>
+
+<style scoped>
+
+.district_link {
+    margin: 10px auto;
+    text-align: center;
+}
+h3 {
+  margin-top: 40px;
+}
+
+</style>
+

--- a/src/router.js
+++ b/src/router.js
@@ -9,6 +9,7 @@ import StateMap from "./components/StateMap.vue"
 import Newsletter from './components/Newsletter.vue'
 import Algorithms from './components/Algorithms.vue'
 import Faq from "./components/Faq.vue";
+import StateFaq from "./components/StateFaq.vue";
 import Help from "./components/Help.vue";
 import Vue from 'vue';
 import VTooltip from 'v-tooltip'
@@ -48,6 +49,15 @@ export default new Router({
             path: '/faq', 
             name: 'faq',
             component: Faq,
+        },    
+        {
+            path: '/faq/:state_code', 
+            name: 'faq-state',
+            props: true,
+            component: StateFaq,
+            beforeEnter: (to, from, next) => {
+                store.dispatch("load_states").then(next)
+            } 
         },    
         {
             path: '/help', 


### PR DESCRIPTION
Adding state specific FAQ route with contact information so each state can add specific FAQ content as well as specific URLS and email/phone numbers for assisting with CEP.